### PR TITLE
Added support for `iteration` parameter

### DIFF
--- a/src/sklearn/main.py
+++ b/src/sklearn/main.py
@@ -464,7 +464,9 @@ def main():
         json.dump(results, f)
 
     est_file = make_filename(
-        'best_estimator', '.pkl', args, rep_name='repetition'
+        'best_estimator' if not args.baselines else 'model', '.pkl',
+        args,
+        rep_name='repetition'
     )
 
     joblib.dump(


### PR DESCRIPTION
This adds `--iteration` capabilities to the main `scikit-learn` script, making it possible to parallelise job execution _without_ overwriting files. Previous behaviour is preserved.